### PR TITLE
Add Earthen race id

### DIFF
--- a/cameraids.lua
+++ b/cameraids.lua
@@ -18,6 +18,8 @@ local races = {
     [9] = "Goblin",
     [52] = "Dracthyr",
     [70] = "Dracthyr",
+    [84] = "Earthen",
+    [85] = "Earthen",
     -- Allied!
     [27] = "Nightborne", -- "Nightborne",
     [28] = "HighmountainTauren", -- "HighmountainTauren",


### PR DESCRIPTION
### Bug
The `races` table is missing entries for the Earthens, this is the cause of issue #26 on line 109 in cameraids.lua when getting the race with `local race = races[raceID or playerRaceID]`.

### Fix
Added ids for male and female Earthen

### Testing
Ran the addon in WoW 11.1 patch without any errors being caught by BugGrabber and BugSack