### PR TITLE
Check IsRectValid before GetCenter to avoid forcing a layout pass from insecure context

### DIFF
--- a/addon.lua
+++ b/addon.lua
@@ -302,6 +302,11 @@ do
         },
     }
     local safecenterscale = function(frame)
+        if not frame:IsRectValid() then
+            -- calling GetCenter on a dirty rect forces a layout pass, which can run
+            -- Blizzard OnSizeChanged handlers in our insecure context (secret value errors)
+            return
+        end
         local scale = frame:GetEffectiveScale()
         local x, y = frame:GetCenter()
         if isanyvaluesecret(x, y) then
@@ -317,6 +322,10 @@ do
         -- Logic here: our tooltip should trend towards the center of the screen, unless something is stopping it.
         -- If comparison tooltips are shown, we shouldn't overlap them
         local originalOwner = owner
+        if not owner:IsRectValid() then
+            -- see safecenterscale; retry on the positioner's next update instead
+            return
+        end
         local x, y = owner:GetCenter()
         if not (x and y) or issecretvalue(x) or issecretframe(owner) then
             return
@@ -337,8 +346,9 @@ do
             local comparisonTooltip1, comparisonTooltip2 = unpack( owner.shoppingTooltips )
             if comparisonTooltip1:IsShown() or comparisonTooltip2:IsShown() then
                 if comparisonTooltip1:IsShown() and comparisonTooltip2:IsShown() then
-                    local c1x, c2x = comparisonTooltip1:GetCenter(), comparisonTooltip2:GetCenter()
-                    if isanyvaluesecret(c1x, c2x) then
+                    local c1x = comparisonTooltip1:IsRectValid() and comparisonTooltip1:GetCenter()
+                    local c2x = comparisonTooltip2:IsRectValid() and comparisonTooltip2:GetCenter()
+                    if not (c1x and c2x) or isanyvaluesecret(c1x, c2x) then
                         outermostComparisonShown = nil
                     elseif c1x > c2x then
                         -- 1 is right of 2


### PR DESCRIPTION
Since 12.0, calling `GetCenter()` on a frame whose rect hasn't been resolved
yet forces an immediate layout pass. When that call comes from addon code, any
pending `OnSizeChanged` handlers run synchronously in our insecure execution
context, and Blizzard code reading frame dimensions there gets secret numbers.

In practice this fires when the positioner runs while an embedded item tooltip
(quest rewards, keystone tooltips, etc.) has just resized and its rect is still
dirty. `ComputeTooltipAnchors` calls `owner:GetCenter()`, which forces the
layout update and runs `EmbeddedItemTooltip_UpdateSize` tainted by us:

```
GameTooltip.lua:764: attempt to perform arithmetic on a secret number value (execution tainted by 'AppearanceTooltip')
[Blizzard_GameTooltip/Mainline/GameTooltip.lua]:764: in function 'EmbeddedItemTooltip_UpdateSize'
[*GameTooltip.xml:96_OnSizeChanged]:1: in function <[string "*GameTooltip.xml:96_OnSizeChanged"]:1>
[C]: in function 'GetCenter'
[AppearanceTooltip/addon.lua]:320: in function 'ComputeTooltipAnchors'
[AppearanceTooltip/addon.lua]:258: in function <AppearanceTooltip/addon.lua:251>
```

This checks `IsRectValid()` before each `GetCenter()` in the positioning path
(the owner, `safecenterscale`, and the two comparison tooltips) and bails out
for that tick if the rect isn't resolved yet. Since the positioner reruns every
`TOOLTIP_UPDATE_TIME`, the layout has been resolved securely by the next tick
and `GetCenter()` just returns the cached values, so positioning is at most
delayed by one update cycle.